### PR TITLE
Build UberJar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.kotlin.gradle.dsl.Coroutines
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -8,6 +9,9 @@ val versionLogback: String by project
 plugins {
     application
     kotlin("jvm") version "1.3.70"
+
+    // Shadow plugin - enable support for building our UberJar
+    id("com.github.johnrengelman.shadow") version "5.2.0"
 }
 
 group = "com.marctatham"
@@ -36,3 +40,23 @@ kotlin.sourceSets["test"].kotlin.srcDirs("test")
 
 sourceSets["main"].resources.srcDirs("resources")
 sourceSets["test"].resources.srcDirs("testresources")
+
+// Configure the "shadowJar" task to properly build our UberJar
+// we effectively want a jar with zero dependencies we can run and will "just work"
+tasks {
+    named<ShadowJar>("shadowJar") {
+        // Appends entries in META-INF/services resources into a single resource. For example, if there are several
+        // META-INF/services/org.apache.maven.project.ProjectBuilder resources spread across many JARs the individual
+        // entries will all be concatenated into a single META-INF/services/org.apache.maven.project.ProjectBuilder
+        // resource packaged into the resultant JAR produced by the shading process -
+        // Effectively ensures we bring along all the necessary bits from Jetty
+        mergeServiceFiles()
+
+        // As per the App Engine java11 standard environment requirements listed here:
+        // https://cloud.google.com/appengine/docs/standard/java11/runtime
+        // Your Jar must contain a Main-Class entry in its META-INF/MANIFEST.MF metadata file
+        manifest {
+            attributes(mapOf("Main-Class" to application.mainClassName))
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 val versionKotlin: String by project
 val versionKtor: String by project
 val versionLogback: String by project
+val versionApp: String by project
+val uberJarFileName: String = "ktor-server-$versionApp-with-dependencies.jar"
 
 plugins {
     application
@@ -15,8 +17,7 @@ plugins {
 }
 
 group = "com.marctatham"
-version = "0.0.1"
-
+version = versionApp
 application {
     mainClassName = "io.ktor.server.jetty.EngineMain"
 }
@@ -45,6 +46,9 @@ sourceSets["test"].resources.srcDirs("testresources")
 // we effectively want a jar with zero dependencies we can run and will "just work"
 tasks {
     named<ShadowJar>("shadowJar") {
+        // explicitly configure the filename of the resulting UberJar
+        archiveFileName.set(uberJarFileName)
+
         // Appends entries in META-INF/services resources into a single resource. For example, if there are several
         // META-INF/services/org.apache.maven.project.ProjectBuilder resources spread across many JARs the individual
         // entries will all be concatenated into a single META-INF/services/org.apache.maven.project.ProjectBuilder

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ kotlin.code.style=official
 versionKotlin=1.3.70
 versionKtor=1.3.2
 versionLogback=1.2.1
+versionApp=0.0.1


### PR DESCRIPTION
Added support for constructing an UberJar that contains the ktor app along with ALL dependencies. 

Constructing the UberJar is as simple as running the relevant gradle task
`./gradlew clean shadowJar`

And running the resulting UberJar is as simple as:
`java -jar build\libs\ktor-appengine-java11-standardenv-0.0.1-all.jar`

```
C:\Users\Marc\Documents\Dev\marctatham\ktor-appengine-java11-standardenv>java -jar build\libs\ktor-appengine-java11-standardenv-0.0.1-all.jar
2020-04-14 15:36:07.451 [main] TRACE Application - {
    # application.conf @ jar:file:/C:/Users/Marc/Documents/Dev/marctatham/ktor-appengine-java11-standardenv/build/libs/ktor-appengine-java11-standardenv-0.0.1-all.jar!/application.conf: 6
    "application" : {
        # application.conf @ jar:file:/C:/Users/Marc/Documents/Dev/marctatham/ktor-appengine-java11-standardenv/build/libs/ktor-appengine-java11-standardenv-0.0.1-all.jar!/application.conf: 7
        "modules" : [
            # application.conf @ jar:file:/C:/Users/Marc/Documents/Dev/marctatham/ktor-appengine-java11-standardenv/build/libs/ktor-appengine-java11-standardenv-0.0.1-all.jar!/application.conf: 7
            "com.marctatham.ApplicationKt.module"
        ]
    },
    # application.conf @ jar:file:/C:/Users/Marc/Documents/Dev/marctatham/ktor-appengine-java11-standardenv/build/libs/ktor-appengine-java11-standardenv-0.0.1-all.jar!/application.conf: 2
    "deployment" : {
        # application.conf @ jar:file:/C:/Users/Marc/Documents/Dev/marctatham/ktor-appengine-java11-standardenv/build/libs/ktor-appengine-java11-standardenv-0.0.1-all.jar!/application.conf: 3
        "port" : 8080
    },
    # Content hidden
    "security" : "***"
}

2020-04-14 15:36:07.528 [main] INFO  org.eclipse.jetty.util.log - Logging initialized @618ms to org.eclipse.jetty.util.log.Slf4jLog
2020-04-14 15:36:07.644 [main] INFO  Application - No ktor.deployment.watch patterns specified, automatic reload is not active
2020-04-14 15:36:08.016 [main] INFO  Application - Responding at http://0.0.0.0:8080
2020-04-14 15:36:08.020 [main] INFO  org.eclipse.jetty.server.Server - jetty-9.4.24.v20191120; built: 2019-11-20T21:37:49.771Z; git: 363d5f2df3a8a28de40604320230664b9c793c16; jvm 11.0.5+10-LTS
2020-04-14 15:36:09.279 [main] INFO  o.e.jetty.server.AbstractConnector - Started ServerConnector@1750fbeb{HTTP/1.1,[http/1.1, h2c]}{0.0.0.0:8080}
2020-04-14 15:36:09.280 [main] INFO  org.eclipse.jetty.server.Server - Started @2378ms
```


