### PR TITLE
Add support for Google App Engine Java11 standard environment

### DIFF
--- a/appengine/app.yaml
+++ b/appengine/app.yaml
@@ -1,0 +1,4 @@
+# More detail regarding the app.yaml can be found here:
+# https://cloud.google.com/appengine/docs/standard/java11/config/appref
+runtime: java11
+instance_class: F1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,10 +87,14 @@ configure<AppEngineAppYamlExtension> {
     }
 
     stage {
-        // configure staging for deployment
+        setAppEngineDirectory("appengine")          // where to find the app.yaml
+        setArtifact("build/libs/$uberJarFileName")  // where to find the artifact to upload
     }
 
     deploy {
-        // configure deployment
+        projectId = "GCLOUD_CONFIG"
+        version = versionApp        // maintain meaningful application versions
+        stopPreviousVersion = true  // stop the current version
+        promote = true              // & make this the current version
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,7 @@ sourceSets["test"].resources.srcDirs("testresources")
 // Configure the "shadowJar" task to properly build our UberJar
 // we effectively want a jar with zero dependencies we can run and will "just work"
 tasks {
-    named<ShadowJar>("shadowJar") {
+    val shadowJarTask = named<ShadowJar>("shadowJar") {
         // explicitly configure the filename of the resulting UberJar
         archiveFileName.set(uberJarFileName)
 
@@ -78,6 +78,16 @@ tasks {
         manifest {
             attributes(mapOf("Main-Class" to application.mainClassName))
         }
+    }
+
+    // because we're using shadowJar, this task has limited value
+    named("jar") {
+        enabled = false
+    }
+
+    // update the `assemble` task to ensure the creation of a brand new UberJar using the shadowJar task
+    named("assemble") {
+        dependsOn(shadowJarTask)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.google.cloud.tools.gradle.appengine.appyaml.AppEngineAppYamlExtension
 import org.jetbrains.kotlin.gradle.dsl.Coroutines
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -8,6 +9,21 @@ val versionLogback: String by project
 val versionApp: String by project
 val uberJarFileName: String = "ktor-server-$versionApp-with-dependencies.jar"
 
+// The `apply` approach of adding plugins is the older, yet more flexible method of adding a plugin to
+// your build. This is the required approach unless your desired plugin is available on Gradle's Plugin Repo.
+// Unfortunately the appengine gradle plugin is not available on Gradle's Plugin Repository:
+// https://github.com/GoogleCloudPlatform/app-gradle-plugin
+buildscript {
+    repositories { jcenter() }
+    dependencies { classpath("com.google.cloud.tools:appengine-gradle-plugin:2.2.0") }
+}
+apply {
+    plugin("com.google.cloud.tools.appengine")
+}
+
+// Note: The `plugins` block is the newer method of applying plugins, but in order to be able to add a plugin
+// via this mechanism they must be available on the Gradle Plugin Repository: http://plugins.gradle.org/
+// where possible, plugins should be added via this section
 plugins {
     application
     kotlin("jvm") version "1.3.70"
@@ -62,5 +78,19 @@ tasks {
         manifest {
             attributes(mapOf("Main-Class" to application.mainClassName))
         }
+    }
+}
+
+configure<AppEngineAppYamlExtension> {
+    tools {
+        // configure the Cloud Sdk tooling
+    }
+
+    stage {
+        // configure staging for deployment
+    }
+
+    deploy {
+        // configure deployment
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,8 @@ kotlin.code.style=official
 versionKotlin=1.3.70
 versionKtor=1.3.2
 versionLogback=1.2.1
-versionApp=0.0.1
+
+# The version of this application
+# May only contain lowercase letters, digits, and hyphens.
+# Must begin and end with a letter or digit
+versionApp=0-0-1


### PR DESCRIPTION
Added & configured the [Google App Engine Gradle plugin](https://github.com/GoogleCloudPlatform/app-gradle-plugin)

As part of this I've also optimized the build to **only** build the UberJar using the `shadowJar` task (instead of building the standard jar with the `jar` task as well)

**Please note:** 
- The `appengine` set of tasks of course require some setup. Please complete the steps listed in [before you begin](https://cloud.google.com/appengine/docs/standard/java11/quickstart#before-you-begin) to be able to test this 
- The [Google Cloud plugin for IntelliJ](https://cloud.google.com/intellij) is NOT required for this in any way, at this time is useful for apps running on the java8 standard environment, but not useful for apps running on the java11 standard environment.

Running `./gradlew appengineDeploy` results in the following 
![Step-4-appengineDeploy - Reducted](https://user-images.githubusercontent.com/1032038/79254049-10bba980-7e7c-11ea-8855-e752e4b624c2.png)

This is of course accessible then via your `PROJET-ID`.appspot.com url which is output upon successful completion of the above gradlew command - alternatively you can find it by executing the Google Cloud CLI command `gcloud app browse`
